### PR TITLE
Fix ParseTime status updates

### DIFF
--- a/lograte/app.go
+++ b/lograte/app.go
@@ -102,6 +102,9 @@ func Main() {
 	var timeRegex *regexp.Regexp
 	if parseTimeRegex != "" {
 		timeRegex = regexp.MustCompile(parseTimeRegex)
+	}
+
+	if parseTimeFormat != "" || ParseTime != nil {
 		start = time.Time{}
 	}
 


### PR DESCRIPTION
Status updates used time.Now() for start, which is a bug if ParseTime is available.